### PR TITLE
fix: 修复启动第一次后监听不成功问题

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -46,7 +46,7 @@ function run() {
   let hasPaths = false;
   let tsconfigPath;
   let isCompileSuccess = false;
-  const fileChangeList = [];
+  const fileChangeList = new Set();
 
   const projectIndex = tscArgs.findIndex(arg => arg === '--project');
   if (projectIndex !== -1) {
@@ -98,8 +98,7 @@ function run() {
   debug(`hasPaths: ${hasPaths}`);
 
   let runChild;
-  const restart = debounce(async () => {
-    if (fileChangeList.length === 0) return;
+  const restart = debounce(async (fileChangeLength = 0) => {
     async function aliasReplace() {
       if (hasPaths) {
         // 这里使用全量替换，tsc 增量编译会把老文件修改回去
@@ -107,15 +106,11 @@ function run() {
           configFile: tsconfigPath,
           outDir,
         });
-        // 避免重复触发文件变化
-        isCompileSuccess = false;
       }
-      output(
-        `${fileChangeList.length} ${colors.dim('Files has been changed.')}`,
+      fileChangeLength && output(
+        `${fileChangeLength} ${colors.dim('Files has been changed.')}`,
         true
       );
-      // 清空文件列表
-      fileChangeList.length = 0;
     }
 
     await Promise.all([runChild && runChild.kill(), aliasReplace()]);
@@ -141,20 +136,25 @@ function run() {
   function cleanOutDirAndRestart() {
     // 碰到任意的删除情况，直接删除整个构建目录
     deleteFolderRecursive(path.join(cwd, outDir));
-    forkTsc(tscArgs, {
+    //在非watch模式下重新编译ts
+    forkTsc(tscArgs.filter(item => item !== "--watch"), {
       cwd,
+      onCompileSuccess: () => {
+        runAfterTsc();
+      }
     });
-    runAfterTsc();
-    restart();
+    // restart();
   }
 
   function onFileChange(p) {
-    // 这里使用了标识来判断是否编译成功，理论上会有时序问题，但是本质上事件还是同步执行的，测试下来感觉没有问题
-    if (!isCompileSuccess) return;
     debug(`${colors.dim('File ')}${p}${colors.dim(' has been changed.')}`);
-    fileChangeList.push(p);
-    // 单个文件的 hot reload 处理
-    restart();
+    fileChangeList.add(p);
+    // 单个文件的 hot reload 处理,编译成功后才触发
+    if(isCompileSuccess){
+      restart(fileChangeList.size);
+      fileChangeList.clear();
+      isCompileSuccess = false;
+    }
   }
 
   // 启动执行 tsc 命令
@@ -206,9 +206,8 @@ function run() {
                  */
                 fileDeleteWatcher = chokidar.watch('**/**.ts', {
                   cwd: path.join(cwd, sourceDir),
-                });
-
-                fileDeleteWatcher.on('unlink', cleanOutDirAndRestart);
+                })
+                .on('unlink', cleanOutDirAndRestart);
 
                 fileDirDeleteWatcher = chokidar
                   .watch('**/**', {
@@ -217,8 +216,8 @@ function run() {
                   .on('unlinkDir', cleanOutDirAndRestart);
 
                 fileChangeWatcher = chokidar
-                  .watch('**/**.js', {
-                    cwd: path.join(cwd, outDir),
+                  .watch('**/**.ts', {
+                    cwd: path.join(cwd, sourceDir),
                   })
                   .on('change', onFileChange);
               }
@@ -235,7 +234,13 @@ function run() {
     },
     onWatchCompileSuccess: () => {
       isCompileSuccess = true;
-      restart();
+      //有文件改变时触发重启
+      if(fileChangeList.size){
+        console.log('onWatchCompileSuccess fileChangeList',fileChangeList.size,'\n\r\n\r');
+        restart(fileChangeList.size);
+        isCompileSuccess = false;
+        fileChangeList.clear();
+      }
     },
     onWatchCompileFail: () => {
       isCompileSuccess = false;

--- a/lib/index.js
+++ b/lib/index.js
@@ -236,7 +236,6 @@ function run() {
       isCompileSuccess = true;
       //有文件改变时触发重启
       if(fileChangeList.size){
-        console.log('onWatchCompileSuccess fileChangeList',fileChangeList.size,'\n\r\n\r');
         restart(fileChangeList.size);
         isCompileSuccess = false;
         fileChangeList.clear();
@@ -279,6 +278,8 @@ function run() {
   process.once('SIGQUIT', onSignal);
   // kill(15) default
   process.once('SIGTERM', onSignal);
+
+  return { restart }
 }
 
 exports.run = run;

--- a/lib/util.js
+++ b/lib/util.js
@@ -58,9 +58,10 @@ exports.debounce = function (func, wait, immediate = false) {
     }
   }
 
-  const debounced = (...args) => {
+  const debounced = (...debounceArgs) => {
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     context = this;
+    args = debounceArgs;
     timestamp = Date.now();
     const callNow = immediate && !timeout;
     if (!timeout) timeout = setTimeout(later, wait);


### PR DESCRIPTION
由监听dist文件夹改为监听soureDir,以避免replaceTscAliasPaths会触发watch。
同时判断编译和文件变更来触发restart，以规避时机问题。

